### PR TITLE
Updated GitIgnore for Linux slnx file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ UserSettings/*
 Assets/Ignored
 
 .vscode/
+**/*.slnx


### PR DESCRIPTION
Updated GitIgnore  to exclude slnx file. The previous one didnt work because the rule "*.slnx" was wrong. 